### PR TITLE
Python 3 fixes

### DIFF
--- a/examples/2D_leave_n_out.py
+++ b/examples/2D_leave_n_out.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 __author__ = 'cpaulson'
 import pyKriging
 from pyKriging.krige import kriging
@@ -15,7 +16,7 @@ testfun = pyKriging.testfunctions().branin
 # We generate our observed values based on our sampling plan and the test function
 y = testfun(X)
 
-print 'Setting up the Kriging Model'
+print('Setting up the Kriging Model')
 cvMSE = []
 # Now that we have our initial data, we can create an instance of a kriging model
 k = kriging(X, y, testfunction=testfun, name='simple', testPoints=300)
@@ -26,7 +27,7 @@ k.snapshot()
 
 k.plot()
 for i in range(15):
-    print i
+    print(i)
     newpoints = k.infill(1)
     for point in newpoints:
         # print 'Adding point {}'.format(point)
@@ -43,15 +44,15 @@ k.plot()
 
 # #And plot the model
 
-print 'Now plotting final results...'
+print('Now plotting final results...')
 # k.plot()
 
 
-print k.testPoints
-print k.history['points']
-print k.history['rsquared']
-print k.history['avgMSE']
-print cvMSE
+print(k.testPoints)
+print(k.history['points'])
+print(k.history['rsquared'])
+print(k.history['avgMSE'])
+print(cvMSE)
 from matplotlib import pylab as plt
 plt.plot(range(len(k.history['rsquared'])), k.history['rsquared'])
 plt.plot(range(len(cvMSE)), cvMSE)

--- a/examples/2D_model_convergence.py
+++ b/examples/2D_model_convergence.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 __author__ = 'cpaulson'
 import pyKriging
 from pyKriging.krige import kriging
@@ -13,7 +14,7 @@ testfun = pyKriging.testfunctions().branin
 # We generate our observed values based on our sampling plan and the test function
 y = testfun(X)
 
-print 'Setting up the Kriging Model'
+print('Setting up the Kriging Model')
 
 # Now that we have our initial data, we can create an instance of a kriging model
 k = kriging(X, y, testfunction=testfun, name='simple', testPoints=250)
@@ -25,17 +26,17 @@ k.snapshot()
 while k.history['rsquared'][-1] < 0.9999:
     newpoints = k.infill(2)
     for point in newpoints:
-        print 'Adding point {}'.format(point)
+        print('Adding point {}'.format(point))
         k.addPoint(point, testfun(point)[0])
     k.train()
     k.snapshot()
-    print 'Current rsquared is: {}'.format(k.history['rsquared'][-1])
+    print('Current rsquared is: {}'.format(k.history['rsquared'][-1]))
 
-print 'The prediction has converged, with {} number of points in the model'.format(k.n)
+print('The prediction has converged, with {} number of points in the model'.format(k.n))
 
 # #And plot the model
 
-print 'Now plotting final results...'
+print('Now plotting final results...')
 k.plot()
 
 

--- a/examples/2D_simple_train.py
+++ b/examples/2D_simple_train.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 __author__ = 'cpaulson'
 import pyKriging
 from pyKriging.krige import kriging
@@ -23,7 +24,7 @@ k.snapshot()
 for i in range(5):
     newpoints = k.infill(2)
     for point in newpoints:
-        print('Adding point {}'.format(point))
+        print(('Adding point {}'.format(point)))
         k.addPoint(point, testfun(point)[0])
     k.train()
     k.snapshot()

--- a/examples/2D_simple_train_expected_improvement.py
+++ b/examples/2D_simple_train_expected_improvement.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 __author__ = 'cpaulson'
 import pyKriging
 from pyKriging.krige import kriging
@@ -15,7 +16,7 @@ y = testfun(X)
 optimizer = 'ga'
 
 # Now that we have our initial data, we can create an instance of a kriging model
-print 'Setting up the Kriging Model'
+print('Setting up the Kriging Model')
 k = kriging(X, y, testfunction=testfun, name='simple_ei', testPoints=300)
 k.train(optimizer=optimizer)
 k.snapshot()
@@ -25,7 +26,7 @@ k.snapshot()
 for i in range(5):
     newpoints = k.infill(1, method='error')
     for point in newpoints:
-        print 'Adding point {}'.format(point)
+        print('Adding point {}'.format(point))
         k.addPoint(point, testfun(point)[0])
     k.train(optimizer=optimizer)
     k.snapshot()
@@ -34,13 +35,13 @@ for i in range(5):
 for i in range(5):
     newpoints = k.infill(1, method='ei')
     for point in newpoints:
-        print 'Adding point {}'.format(point)
+        print('Adding point {}'.format(point))
         k.addPoint(point, testfun(point)[0])
     k.train(optimizer=optimizer)
     k.snapshot()
 
 # And plot the results
-print 'Now plotting final results...'
+print('Now plotting final results...')
 k.plot()
 
 

--- a/examples/2d_regression_Kriging.py
+++ b/examples/2d_regression_Kriging.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 __author__ = 'cpaulson'
 import sys
 sys.path.insert(0, '../')
@@ -16,26 +17,26 @@ testfun = pyKriging.testfunctions().branin_noise
 
 # We generate our observed values based on our sampling plan and the test function
 y = testfun(X)
-print X, y
+print(X, y)
 
 testfun = pyKriging.testfunctions().branin
 
 
-print 'Setting up the Kriging Model'
+print('Setting up the Kriging Model')
 
 # Now that we have our initial data, we can create an instance of a kriging model
 k = regression_kriging(X, y, testfunction=testfun, name='simple', testPoints=250)
 k.train(optimizer='pso')
 k1 = kriging(X, y, testfunction=testfun, name='simple', testPoints=250)
 k1.train(optimizer='pso')
-print k.Lambda
+print(k.Lambda)
 k.snapshot()
 
 
 for i in range(1):
     newpoints = k.infill(5)
     for point in newpoints:
-        print 'Adding point {}'.format(point)
+        print('Adding point {}'.format(point))
         newValue = testfun(point)[0]
         k.addPoint(point, newValue)
         k1.addPoint(point, newValue)
@@ -45,8 +46,8 @@ for i in range(1):
 #
 # # #And plot the model
 
-print 'Now plotting final results...'
-print k.Lambda
+print('Now plotting final results...')
+print(k.Lambda)
 k.plot(show=False)
 k1.plot()
 

--- a/examples/3d_Simple_Train.py
+++ b/examples/3d_Simple_Train.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pyKriging
 from pyKriging.krige import kriging
 from pyKriging.samplingplan import samplingplan
@@ -23,13 +24,13 @@ k.snapshot()
 # The infill method can be  used for this
 # In this example, we will add nine points in three batches. The model gets trained after each stage
 for i in range(10):
-    print k.history['rsquared'][-1]
-    print 'Infill iteration {0}'.format(i + 1)
+    print(k.history['rsquared'][-1])
+    print('Infill iteration {0}'.format(i + 1))
     infillPoints = k.infill(10)
 
     # Evaluate the infill points and add them back to the Kriging model
     for point in infillPoints:
-        print 'Adding point {}'.format(point)
+        print('Adding point {}'.format(point))
         k.addPoint(point, testfun(point)[0])
 
     # Retrain the model with the new points added in to the model

--- a/examples/coKriging.py
+++ b/examples/coKriging.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 __author__ = 'cpaulson'
 
 import sys
@@ -14,8 +15,8 @@ def cheap(X):
     C=-5
     D=0
 
-    print X
-    print ((X+D)*6-2)
+    print(X)
+    print(((X+D)*6-2))
     return A*np.power( ((X+D)*6-2), 2 )*np.sin(((X+D)*6-2)*2)+((X+D)-0.5)*B+C
 
 def expensive(X):
@@ -30,7 +31,7 @@ ye = expensive(Xe)
 
 ck = coKriging.coKriging(Xc, yc, Xe, ye)
 ck.thetac = np.array([1.2073])
-print ck.Xc
+print(ck.Xc)
 ck.updateData()
 ck.updatePsi()
 ck.neglnlikehood()

--- a/pyKriging/samplingplan.py
+++ b/pyKriging/samplingplan.py
@@ -278,12 +278,9 @@ class samplingplan():
         for i in range(len(distinct_d)):
             #J(i) will contain the number of pairs separated
             #by the distance distinct_d(i)
-            J[i]=np.sum(self.ismember(d,distinct_d[i]))
+            J[i] = np.sum(d == distinct_d[i])
 
         return J, distinct_d
-
-    def ismember(self, A, B):
-        return [ np.sum(a == B) for a in A ]
 
     def mm(self,X1,X2,p=1):
         """

--- a/pyKriging/samplingplan.py
+++ b/pyKriging/samplingplan.py
@@ -251,7 +251,7 @@ class samplingplan():
         n = np.size(X[:,1])
 
         #computes the distances between all pairs of points
-        d = np.zeros((n*(n-1)/2))
+        d = np.zeros((n*(n-1)//2))
 
 
 

--- a/pyKriging/samplingplan.py
+++ b/pyKriging/samplingplan.py
@@ -269,16 +269,7 @@ class samplingplan():
 
 
         #remove multiple occurences
-        distinct_d = np.unique(d)
-
-        #pre-allocate memory for J
-        J = np.zeros(np.size(distinct_d))
-
-        #generate multiplicity array
-        for i in range(len(distinct_d)):
-            #J(i) will contain the number of pairs separated
-            #by the distance distinct_d(i)
-            J[i] = np.sum(d == distinct_d[i])
+        distinct_d, J = np.unique(d, return_counts=True)
 
         return J, distinct_d
 

--- a/pyKriging/samplingplan.py
+++ b/pyKriging/samplingplan.py
@@ -158,14 +158,14 @@ class samplingplan():
         [n,k] = np.shape(X_pert)
 
         for pert_count in range(0,PertNum):
-            col = m.floor(np.random.rand(1)*k)
+            col = int(m.floor(np.random.rand(1)*k))
 
             #Choosing two distinct random points
             el1 = 0
             el2 = 0
             while el1 == el2:
-                el1 = m.floor(np.random.rand(1)*n)
-                el2 = m.floor(np.random.rand(1)*n)
+                el1 = int(m.floor(np.random.rand(1)*n))
+                el2 = int(m.floor(np.random.rand(1)*n))
 
             #swap the two chosen elements
             arrbuffer = X_pert[el1,col]


### PR DESCRIPTION
This PR is against the Python3-Support branch.

- print() functions in the examples, so I can run them in Python 3. Uses `from __future__ import print_function` so they still work for Python 2 as well.
- Fixed one instance where integer division was needed in `pyKriging.samplingplan`

I also profiled the sampling plan stage, and found a simple way to make it much faster - on my machine the `2D_model_convergence.py` sample planning stage went from about 3 minutes to 10 seconds.

The version of the code in this PR requires numpy 1.9 or above (for the `return_counts` parameter in numpy.unique). 1.9 was released in September 2014, so most users should have a new enough version. If you want to support older versions of numpy, the last-but-one commit is almost as fast.