### PR TITLE
Added int() calls around m.floor return values to be used as indices

### DIFF
--- a/pyKriging/samplingplan.py
+++ b/pyKriging/samplingplan.py
@@ -155,14 +155,14 @@ class samplingplan():
         [n,k] = np.shape(X_pert)
 
         for pert_count in range(0,PertNum):
-            col = m.floor(np.random.rand(1)*k)
+            col = int(m.floor(np.random.rand(1)*k))
 
             #Choosing two distinct random points
             el1 = 0
             el2 = 0
             while el1 == el2:
-                el1 = m.floor(np.random.rand(1)*n)
-                el2 = m.floor(np.random.rand(1)*n)
+                el1 = int(m.floor(np.random.rand(1)*n))
+                el2 = int(m.floor(np.random.rand(1)*n))
 
             #swap the two chosen elements
             arrbuffer = X_pert[el1,col]


### PR DESCRIPTION
I had error messages when creating a new sampling plan in anything other than 2D. Turned out that math.floor was being used to generate indices, but their returned float values were not accepted. Placing those lines in int(...) calls was enough to fix the problem.