### PR TITLE
added missing import in coKriging.py

### DIFF
--- a/pyKriging/coKriging.py
+++ b/pyKriging/coKriging.py
@@ -1,5 +1,6 @@
 __author__ = 'cpaulson'
 
+from sys import exit
 import numpy as np
 from numpy.matlib import rand,zeros,ones,empty,eye
 from pyKriging import kriging


### PR DESCRIPTION
I added the missing import for sys.exit, which causes a bug when executing examples/coKriging.py